### PR TITLE
Migrate to target api

### DIFF
--- a/src/app-env.ts
+++ b/src/app-env.ts
@@ -1,6 +1,7 @@
-import { IAPIClient, ISession, ITabResponse } from 'chrome-debugging-client';
+import { IDebuggingProtocolClient, ISession } from 'chrome-debugging-client';
 import { ClientEnvironment } from './models/client';
 import { TestServerApi } from './test-server-api';
+import { Target } from 'chrome-debugging-client/dist/protocol/tot';
 
 /**
  * API for interacting with the complete running test application
@@ -9,32 +10,64 @@ import { TestServerApi } from './test-server-api';
  * @public
  */
 export class TestEnvironment<S extends TestServerApi = TestServerApi> {
-  private client: IAPIClient;
-  private session: ISession;
   private testServer: S;
   private activeClient: ClientEnvironment;
+  private targetDomain: Target;
+  private session: ISession;
 
-  private tabIdToClientEnv: {[tabId: string]: ClientEnvironment};
+  private browserContextId: string;
 
-  private constructor(client: IAPIClient, session: ISession, testServer: S) {
-    this.client = client;
-    this.session = session;
+  private targetIdToClientEnv: {[targetId: string]: ClientEnvironment};
+  private clientEnvIndex: ClientEnvironment[];
+
+  private browserClient: IDebuggingProtocolClient;
+
+  private constructor(browserClient: IDebuggingProtocolClient, session: ISession, testServer: S) {
     this.testServer = testServer;
-    this.tabIdToClientEnv = {};
+    this.targetIdToClientEnv = {};
+    this.clientEnvIndex = [];
+    this.browserClient = browserClient;
+    this.targetDomain = new Target(browserClient);
+    this.session = session;
+  }
+
+  public async createTarget(): Promise<ClientEnvironment> {
+    const { targetId } = await this.targetDomain.createTarget({
+      browserContextId: this.browserContextId,
+      url: 'about:blank',
+    });
+    const debuggingClient = await this.session.attachToTarget(this.browserClient, targetId);
+    const env = await this.buildClientEnv(debuggingClient, targetId);
+    this.clientEnvIndex.push(env);
+    if (!this.activeClient) {
+      this.activeClient = env;
+    }
+    return env;
+  }
+
+  public async createBrowserContext() {
+    this.browserContextId = (await this.targetDomain.createBrowserContext()).browserContextId;
+  }
+
+  public async activateTabByIndex(index: number) {
+    if (index < 0 || index >= this.clientEnvIndex.length) {
+      throw new Error('Invalid tab index');
+    }
+    await this.activateTabClient(this.clientEnvIndex[index]);
   }
 
   public static async build<S extends TestServerApi = TestServerApi>
-    (client: IAPIClient, session: ISession, testServer: S) {
-    const tabs = await client.listTabs();
-    const initialTab = tabs[0];
-
-    const appEnv = new TestEnvironment(client, session, testServer);
-    await appEnv.buildClientEnv(initialTab);
-    await appEnv.activateTab(initialTab.id);
+    (browserClient: IDebuggingProtocolClient, session: ISession, testServer: S) {
+    const appEnv = new TestEnvironment(browserClient, session, testServer);
+    await appEnv.createBrowserContext();
     return appEnv;
   }
 
   public getActiveTabClient(): ClientEnvironment {
+    if (!this.activeClient) {
+      throw new Error(`No active tab client exists. Have you tried creating one first?
+        You can do so using TestEnvironment.createTarget()`);
+    }
     return this.activeClient;
   }
 
@@ -43,42 +76,26 @@ export class TestEnvironment<S extends TestServerApi = TestServerApi> {
   }
 
   public async createTab(): Promise<ClientEnvironment> {
-    const tab = await this.client.newTab();
-    return this.buildClientEnv(tab);
+    return this.createTab();
   }
 
   public activateTabById(id: string) {
     return this.activateTab(id);
   }
 
+  public async emulateOffline(offline: boolean = true) {
+    throw new Error('Offline emulation not working. See https://bugs.chromium.org/p/chromium/issues/detail?id=852127');
+    /*
+    await Promise.all(this.clientEnvIndex.map((client) => {
+      return client.emulateOffline(offline);
+    }));
+    */
+  }
+
   public async createAndActivateTab() {
-    await this.createTab();
-    await this.activateLastTab();
-    return this.getActiveTabClient();
-  }
-
-  private async getTabs() {
-    const tabs = await this.client.listTabs();
-    return tabs.filter(({ type }) => {
-      return type === 'page';
-    });
-  }
-
-  // This method is probably broken
-  public async activateTabByIndex(index: number) {
-    const tabs = await this.getTabs();
-    const rawIndex = tabs.length - 1 - index;
-    if (rawIndex >= 0) {
-      return this.activateTabById(tabs[rawIndex].id);
-    }
-  }
-
-  public async activateLastTab() {
-    const tabs = await this.getTabs();
-    if (tabs.length > 0) {
-      const last = tabs[0];
-      return this.activateTabById(last.id);
-    }
+    const tab = await this.createTarget();
+    await this.activateTabClient(tab);
+    return tab;
   }
 
   public async closeTab() {
@@ -86,26 +103,28 @@ export class TestEnvironment<S extends TestServerApi = TestServerApi> {
   }
 
   public async close() {
-    const tabIds = Object.keys(this.tabIdToClientEnv);
-    return Promise.all(tabIds.map((tabId) => {
-      return this.tabIdToClientEnv[tabId].close();
+    const targetIds = Object.keys(this.targetIdToClientEnv);
+    return Promise.all(targetIds.map((targetId) => {
+      return this.targetIdToClientEnv[targetId].close();
     }));
   }
 
   public async activateTabClient(client: ClientEnvironment) {
-    await this.activateTabById(client.tab.id);
+    await this.activateTabById(client.targetId);
   }
 
-  private async buildClientEnv(tab: ITabResponse): Promise<ClientEnvironment> {
-    const dp = await this.session.openDebuggingProtocol(tab.webSocketDebuggerUrl || '');
-    const client = await ClientEnvironment.build(dp, this.testServer.rootUrl, tab);
-    this.tabIdToClientEnv[tab.id] = client;
+  private async buildClientEnv(targetClient: IDebuggingProtocolClient, targetId: string): Promise<ClientEnvironment> {
+    const client = await ClientEnvironment.build(
+      this.session, this.browserClient, targetClient, this.testServer.rootUrl, targetId);
+    this.targetIdToClientEnv[targetId] = client;
     return client;
   }
 
-  private async activateTab(tabId: string) {
-    await this.client.activateTab(tabId);
-    this.activeClient = this.tabIdToClientEnv[tabId];
+  private async activateTab(targetId: string) {
+    const client = this.targetIdToClientEnv[targetId];
+    this.activeClient = client;
+    // TODO: Migrate to sessionID
+    await this.targetDomain.activateTarget({ targetId });
   }
 }
 

--- a/src/models/service-worker-state.ts
+++ b/src/models/service-worker-state.ts
@@ -1,6 +1,7 @@
 import {
-  ServiceWorker
+  ServiceWorker, Network
 } from 'chrome-debugging-client/dist/protocol/tot';
+import { ISession, IDebuggingProtocolClient } from 'chrome-debugging-client';
 
 export interface VersionStatusIdentifier {
   status: ServiceWorker.ServiceWorkerVersionStatus;
@@ -89,6 +90,38 @@ export interface IServiceWorker {
 
 type VersionListener = (v: ServiceWorker.ServiceWorkerVersion) => void;
 
+interface ServiceWorkerCore {
+  client: IDebuggingProtocolClient;
+  networkDomain: Network;
+}
+
+class ServiceWorkerProtocolSession {
+  private core: Promise<ServiceWorkerCore>;
+  constructor(public targetId: string, clientP: Promise<IDebuggingProtocolClient>) {
+    this.core = clientP.then(async (client) => {
+      const networkDomain = new Network(client);
+      await networkDomain.enable({});
+      return {
+        client,
+        networkDomain
+      };
+    });
+  }
+  public async emulateOffline(offline: boolean) {
+    await this.core;
+    throw new Error('Offline emulation not working. See https://bugs.chromium.org/p/chromium/issues/detail?id=852127');
+    /*
+    const { networkDomain } = await this.core;
+    if (offline) {
+      console.log('sw emulate', this.targetId);
+      await emulateOffline(networkDomain);
+    } else {
+      await turnOffEmulateOffline(networkDomain);
+    }
+    */
+  }
+}
+
 /**
  * ServiceWorkerState config options
  * @internal
@@ -119,13 +152,26 @@ export class ServiceWorkerState {
   private stateListeners: StateIdArrayMap<VersionListener>;
   private stateHistory: StateIdMap<ServiceWorker.ServiceWorkerVersion>;
 
+  private targets: Map<string, ServiceWorkerProtocolSession>;
+  private session: ISession;
+  private browserClient: IDebuggingProtocolClient;
+
   private errorCallbacks: ServiceWorkerErrorCallback[];
 
-  constructor(serviceWorker: IServiceWorker, options: IServiceWorkerStateOptions = {}) {
+  constructor(
+    session: ISession,
+    browserClient: IDebuggingProtocolClient,
+    serviceWorker: IServiceWorker,
+    options: IServiceWorkerStateOptions = {}
+  ) {
     this.versions = new Map();
     this.stateListeners = new StateIdArrayMap();
     this.stateHistory = new StateIdMap();
     this.log = !!options.log;
+
+    this.targets = new Map();
+    this.session = session;
+    this.browserClient = browserClient;
 
     this.errorCallbacks = [];
 
@@ -184,6 +230,11 @@ export class ServiceWorkerState {
     this.versions.set(Number(version.versionId), version);
     const id = identifierFromVersion(version);
     this.stateHistory.set(id, version);
+
+    if (version.targetId && !this.targets.has(version.targetId)) {
+      const attach = this.session.attachToTarget(this.browserClient, version.targetId);
+      this.targets.set(version.targetId, new ServiceWorkerProtocolSession(version.targetId, attach));
+    }
 
     if (version.status === 'activated' && version.runningStatus === 'running') {
       this.handleActivated(version);
@@ -278,5 +329,19 @@ export class ServiceWorkerState {
     return this.serviceWorker.skipWaiting({
       scopeURL: '/'
     });
+  }
+
+  public emulateOffline(offline: boolean) {
+    throw new Error('Offline emulation not working. See https://bugs.chromium.org/p/chromium/issues/detail?id=852127');
+    /*
+    return Promise.all(Array.from(this.targets).map(([key, sw]) => {
+      return sw.emulateOffline(offline);
+    }));
+    */
+  }
+
+  public close() {
+    // TODO: Once we move to using new BrowserContext per test, instead of an entire new ISession,
+    // we need to manually close all the ServiceWorkerProtocolSessions
   }
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -55,10 +55,17 @@ export class TestSession<S extends TestServerApi = TestServerApi> {
   ) {
     return createSession(async (session) => {
       const browser = await this.spawnBrowser(session, options);
-      const apiClient = session.createAPIClient('localhost', browser.remoteDebuggingPort);
 
-      const appEnv = await TestEnvironment.build(apiClient, session, server);
+      const browserClient = await session.openDebuggingProtocol(
+        browser.webSocketDebuggerUrl!,
+      );
+
+      // TODO: This might be useful once offline throttling works:
+      // await autoAttach(browserClient, 'localhost', browser.remoteDebuggingPort);
+
+      const appEnv = await TestEnvironment.build(browserClient, session, server);
       await test(appEnv);
+
       await appEnv.close();
     });
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,58 @@
+import {
+  Target
+} from 'chrome-debugging-client/dist/protocol/tot';
+import { IDebuggingProtocolClient, ISession } from 'chrome-debugging-client';
+
+/*
+// Offline stuff doesn't work right now: https://bugs.chromium.org/p/chromium/issues/detail?id=852127
+export async function emulateOffline(network: Network) {
+  console.log('emulating network conditions');
+  await network.emulateNetworkConditions({
+    offline: true,
+    latency: 0,
+    downloadThroughput: 0,
+    uploadThroughput: 0,
+    connectionType: 'none'
+  });
+}
+
+export async function turnOffEmulateOffline(network: Network) {
+  console.log('TURN OFF BAD');
+  await network.emulateNetworkConditions({
+    offline: false,
+    latency: 0,
+    downloadThroughput: -1,
+    uploadThroughput: -1
+  });
+}
+
+export async function clientEmulateOffline(session: ISession, client: IDebuggingProtocolClient): Promise<any> {
+  return forEachTarget(session, client, (c) => {
+    return emulateOffline(new Network(c));
+  });
+}
+
+export async function turnOffClientEmulateOffline(session: ISession, client: IDebuggingProtocolClient): Promise<any> {
+  return forEachTarget(session, client, (c) => {
+    return emulateOffline(new Network(c));
+  });
+}
+*/
+
+export type ClientCallback = (c: IDebuggingProtocolClient) => Promise<void>;
+
+export async function forEachTarget(
+  s: ISession,
+  client: IDebuggingProtocolClient,
+  cb: ClientCallback
+): Promise<any> {
+  const t = new Target(client);
+  const targets = await t.getTargets();
+  if (!targets.targetInfos) {
+    return Promise.resolve();
+  }
+  const clients = await Promise.all(targets.targetInfos.map(({ targetId }) => s.attachToTarget(client, targetId)));
+  return Promise.all(clients.map(async (targetClient) => {
+    await cb(targetClient);
+  }));
+}

--- a/test/acceptance/basic.spec.ts
+++ b/test/acceptance/basic.spec.ts
@@ -15,7 +15,7 @@ after(session.close.bind(session));
 describe('Service Worker', () => {
   it('should have a version', async () => {
     await session.run(async (testEnv) => {
-      const client = testEnv.getActiveTabClient();
+      const client = await testEnv.createTarget();
       await client.navigate();
 
       await client.evaluate(function() {
@@ -29,7 +29,7 @@ describe('Service Worker', () => {
 
   it('should intercept basepage request and add meta tag', async () => {
     await session.run(async (testEnv) => {
-      const client = testEnv.getActiveTabClient();
+      const client = await testEnv.createTarget();
       await client.navigate();
 
       await client.evaluate(function() {
@@ -47,7 +47,7 @@ describe('Service Worker', () => {
 
   it('should intercept basepage request for tabs that were created before the worker was registered', async () => {
     await session.run(async (testEnv) => {
-      const client1 = testEnv.getActiveTabClient();
+      const client1 = await testEnv.createTarget();
       await client1.navigate();
 
       const client2 = await testEnv.createAndActivateTab();
@@ -85,7 +85,7 @@ describe('Service Worker', () => {
   it('should throw on service worker error by default', async () => {
     const shouldReject = async () => {
       await session.run(async (testEnv) => {
-        const client = testEnv.getActiveTabClient();
+        const client = await testEnv.createTarget();
         await client.navigate();
 
         await client.evaluate(function() {
@@ -116,7 +116,7 @@ describe('Service Worker', () => {
 
   it('should not throw on service worker error if error is caught', async () => {
     await session.run(async (testEnv) => {
-      const client = testEnv.getActiveTabClient();
+      const client = await testEnv.createTarget();
 
       // Catch errors and don't re-throw
       client.swState.catchErrors(() => {});
@@ -145,7 +145,7 @@ describe('Service Worker', () => {
 
   it('active version should only change after skipWaiting', async () => {
     await session.run(async (testEnv) => {
-      const client = testEnv.getActiveTabClient();
+      const client = await testEnv.createTarget();
 
       await client.navigate();
 
@@ -188,7 +188,7 @@ describe('Service Worker', () => {
     try {
       try {
         await session.run(async (testEnv) => {
-          const client = testEnv.getActiveTabClient();
+          const client = await testEnv.createTarget();
 
           await client.navigate();
 

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -14,5 +14,5 @@
     "outDir": "dist"
   },
   "files": ["./server/standalone.ts"],
-  "include": ["./acceptance/*.ts", "./unit/*.ts"]
+  "include": ["./acceptance/*.ts", "./unit/*.spec.ts"]
 }

--- a/test/unit/service-worker-state.spec.ts
+++ b/test/unit/service-worker-state.spec.ts
@@ -1,112 +1,99 @@
 import { expect } from 'chai';
-import { ServiceWorkerState, IServiceWorker } from './../../src';
-import {
-  ServiceWorker
-} from 'chrome-debugging-client/dist/protocol/tot';
-
-class TestServiceWorker implements IServiceWorker {
-  public workerErrorReported: ServiceWorker.WorkerErrorReportedHandler;
-  public workerRegistrationUpdated: ServiceWorker.WorkerRegistrationUpdatedHandler;
-  public workerVersionUpdated: ServiceWorker.WorkerVersionUpdatedHandler;
-
-  skipWaiting() {
-    return Promise.resolve();
-  }
-}
+import { runMockScenario } from './utils';
 
 describe('Service Worker State', () => {
   describe('waitForActivated', () => {
     it('should wait for activation event', async () => {
-      const sw = new TestServiceWorker();
-      const state = new ServiceWorkerState(sw);
-      const activatedPromise = state.waitForActivated();
-      sw.workerVersionUpdated({
-        versions: [{
-          versionId: '0',
-          registrationId: '0',
-          scriptURL: '',
-          runningStatus: 'running',
-          status: 'activated'
-        }]
-      });
+      await runMockScenario(async (state, sw) => {
+        const activatedPromise = state.waitForActivated();
+        sw.workerVersionUpdated({
+          versions: [{
+            versionId: '0',
+            registrationId: '0',
+            scriptURL: '',
+            runningStatus: 'running',
+            status: 'activated'
+          }]
+        });
 
-      const version = await activatedPromise;
-      expect(version.versionId).to.equal('0');
+        const version = await activatedPromise;
+        expect(version.versionId).to.equal('0');
+      });
     });
 
     it('should wait for activation event when passed a version after the event happens', async () => {
-      const sw = new TestServiceWorker();
-      const state = new ServiceWorkerState(sw);
-      sw.workerVersionUpdated({
-        versions: [{
-          versionId: '1',
-          registrationId: '0',
-          scriptURL: '',
-          runningStatus: 'running',
-          status: 'activated'
-        }]
-      });
+      await runMockScenario(async (state, sw) => {
+        sw.workerVersionUpdated({
+          versions: [{
+            versionId: '1',
+            registrationId: '0',
+            scriptURL: '',
+            runningStatus: 'running',
+            status: 'activated'
+          }]
+        });
 
-      const version = await state.waitForActivated('1');
-      expect(version.versionId).to.equal('1');
+        const version = await state.waitForActivated('1');
+        expect(version.versionId).to.equal('1');
+      });
     });
 
     it('should wait for activation event when passed a version before the event happens', async () => {
-      const sw = new TestServiceWorker();
-      const state = new ServiceWorkerState(sw);
-      const activatedPromise = state.waitForActivated('1');
-      sw.workerVersionUpdated({
-        versions: [{
-          versionId: '1',
-          registrationId: '0',
-          scriptURL: '',
-          runningStatus: 'running',
-          status: 'activated'
-        }]
-      });
+      await runMockScenario(async (state, sw) => {
+        const activatedPromise = state.waitForActivated('1');
+        sw.workerVersionUpdated({
+          versions: [{
+            versionId: '1',
+            registrationId: '0',
+            scriptURL: '',
+            runningStatus: 'running',
+            status: 'activated'
+          }]
+        });
 
-      const version = await activatedPromise;
-      expect(version.versionId).to.equal('1');
+        const version = await activatedPromise;
+        expect(version.versionId).to.equal('1');
+      });
     });
 
     it('should wait for retroactive activation event with multiple listeners', async () => {
-      const sw = new TestServiceWorker();
-      const state = new ServiceWorkerState(sw);
-      sw.workerVersionUpdated({
-        versions: [{
-          versionId: '1',
-          registrationId: '0',
-          scriptURL: '',
-          runningStatus: 'running',
-          status: 'activated'
-        }]
-      });
+      await runMockScenario(async (state, sw) => {
+        sw.workerVersionUpdated({
+          versions: [{
+            versionId: '1',
+            registrationId: '0',
+            scriptURL: '',
+            runningStatus: 'running',
+            status: 'activated'
+          }]
+        });
 
-      const version = await state.waitForActivated('1');
-      const version1 = await state.waitForActivated('1');
-      expect(version.versionId).to.equal('1');
-      expect(version1.versionId).to.equal('1');
+        const version = await state.waitForActivated('1');
+        const version1 = await state.waitForActivated('1');
+        expect(version.versionId).to.equal('1');
+        expect(version1.versionId).to.equal('1');
+      });
     });
 
     it('should wait for activation event with multiple listeners', async () => {
-      const sw = new TestServiceWorker();
-      const state = new ServiceWorkerState(sw);
-      const activatedPromise = state.waitForActivated('1');
-      const activatedPromise2 = state.waitForActivated('1');
-      sw.workerVersionUpdated({
-        versions: [{
-          versionId: '1',
-          registrationId: '0',
-          scriptURL: '',
-          runningStatus: 'running',
-          status: 'activated'
-        }]
-      });
+      await runMockScenario(async (state, sw) => {
+        const activatedPromise = state.waitForActivated('1');
+        const activatedPromise2 = state.waitForActivated('1');
+        sw.workerVersionUpdated({
+          versions: [{
+            versionId: '1',
+            registrationId: '0',
+            scriptURL: '',
+            runningStatus: 'running',
+            status: 'activated'
+          }]
+        });
 
-      const version = await activatedPromise;
-      const version2 = await activatedPromise2;
-      expect(version.versionId).to.equal('1');
-      expect(version2.versionId).to.equal('1');
+        const version = await activatedPromise;
+        const version2 = await activatedPromise2;
+        expect(version.versionId).to.equal('1');
+        expect(version2.versionId).to.equal('1');
+      });
     });
   });
 });

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -1,0 +1,31 @@
+import { ServiceWorkerState, IServiceWorker } from './../../src';
+import {
+  ServiceWorker
+} from 'chrome-debugging-client/dist/protocol/tot';
+import { createSession } from 'chrome-debugging-client';
+
+class TestServiceWorker implements IServiceWorker {
+  public workerErrorReported: ServiceWorker.WorkerErrorReportedHandler;
+  public workerRegistrationUpdated: ServiceWorker.WorkerRegistrationUpdatedHandler;
+  public workerVersionUpdated: ServiceWorker.WorkerVersionUpdatedHandler;
+
+  skipWaiting() {
+    return Promise.resolve();
+  }
+}
+
+type Scenario = (state: ServiceWorkerState, sw: TestServiceWorker) => Promise<void>;
+
+export async function runMockScenario(cb: Scenario) {
+  await createSession(async (session) => {
+    const sw = new TestServiceWorker();
+    const browser = await session.spawnBrowser({
+      additionalArguments: ['--headless'],
+    });
+    const browserClient = await session.openDebuggingProtocol(
+      browser.webSocketDebuggerUrl!,
+    );
+    const state = new ServiceWorkerState(session, browserClient, sw);
+    await cb(state, sw);
+  });
+}


### PR DESCRIPTION
Uses the new Chrome Remote Protocol target API. This sets up future work to use browser contexts 
so we can run each test in isolation without having to create a new chrome process every time. It also is just a nicer api to work with.