### PR TITLE
Add ability to close tabs and get all responses from navigate

### DIFF
--- a/src/app-env.ts
+++ b/src/app-env.ts
@@ -98,14 +98,19 @@ export class TestEnvironment<S extends TestServerApi = TestServerApi> {
     return tab;
   }
 
-  public async closeTab() {
-    // TODO: Call ensureNoErrors() on the tab
+  public async closeTab(targetId: string) {
+    if (!(targetId in this.targetIdToClientEnv)) {
+      throw new Error(`Can't close tab with targetId:{$targetId}. ` +
+                      'This targetId is not associated with this TestEnvironment');
+    }
+    await this.targetIdToClientEnv[targetId].close();
+    delete this.targetIdToClientEnv[targetId];
   }
 
   public async close() {
     const targetIds = Object.keys(this.targetIdToClientEnv);
     return Promise.all(targetIds.map((targetId) => {
-      return this.targetIdToClientEnv[targetId].close();
+      return this.closeTab(targetId);
     }));
   }
 

--- a/test/acceptance/utils.ts
+++ b/test/acceptance/utils.ts
@@ -1,0 +1,5 @@
+export function wait(time: number) {
+  return new Promise((r) => {
+    setTimeout(r, time);
+  });
+}


### PR DESCRIPTION
This adds the ability to:
1) Close tabs
2) Get response bodies from a navigate

To ensure we get all responses, if waitForLoad === true, then we:
1) Wait for both the onload event 
2) Count all requests and responses and make sure the two counts match to ensure there are no responses still inflight.